### PR TITLE
[CleanUp] APIs return errors array for all fails

### DIFF
--- a/controllers/eventController.js
+++ b/controllers/eventController.js
@@ -1,81 +1,79 @@
-import Event from "../models/eventModel.js";
+import Event from '../models/eventModel.js';
 
 export const getAllEvents = async (req, res) => {
-try {
-  const events = await Event.find();
-  console.log(events);
+  try {
+    const events = await Event.find();
     if (events.length === 0) {
       return res.status(404).json({
-        status: "fail",
-        message: "No events have been made yet",
+        status: 'fail',
+        errors: ['No events have been made yet'],
       });
     }
     return res.status(200).json({
-      status: "success",
+      status: 'success',
       results: events.length,
       data: {
         events,
       },
     });
-} catch (e) {
+  } catch (e) {
     return res.status(500).json({
-      status: "fail",
-      message: e.message,
+      status: 'fail',
+      errors: [e.message],
     });
-}
-}
+  }
+};
 
 export const createEvent = async (req, res) => {
-
-  try{
+  try {
     const {
-    img,
-    title,
-    description,
-    contactEmail,
-    eventLocation,
-    maxCapacity,
-    priceOfAdmission,
-    comments,
-    user,
-    eventDate,
-    startTime,
-    endTime,
-    publicEvent,
-    attendees,
-    totalNumberOfAttendees,
-  } = req.body;
+      img,
+      title,
+      description,
+      contactEmail,
+      eventLocation,
+      maxCapacity,
+      priceOfAdmission,
+      comments,
+      user,
+      eventDate,
+      startTime,
+      endTime,
+      publicEvent,
+      attendees,
+      totalNumberOfAttendees,
+    } = req.body;
 
-  const newEvent = await Event.create({img,
-    title,
-    description,
-    contactEmail,
-    eventLocation,
-    maxCapacity,
-    priceOfAdmission,
-    comments,
-    user,
-    eventDate,
-    startTime,
-    endTime,
-    publicEvent,
-    attendees,
-    totalNumberOfAttendees});
-  
-  return res.status(201).json({
-    status: "success",
-    data: {
-      event: newEvent,
-    },
-  });
-}
-catch(e)
-{
-  return res.status(500).json({
-    status: "fail",
-    message: e.message,
-  });
-}
+    const newEvent = await Event.create({
+      img,
+      title,
+      description,
+      contactEmail,
+      eventLocation,
+      maxCapacity,
+      priceOfAdmission,
+      comments,
+      user,
+      eventDate,
+      startTime,
+      endTime,
+      publicEvent,
+      attendees,
+      totalNumberOfAttendees,
+    });
+
+    return res.status(201).json({
+      status: 'success',
+      data: {
+        event: newEvent,
+      },
+    });
+  } catch (e) {
+    return res.status(500).json({
+      status: 'fail',
+      errors: [e.message],
+    });
+  }
 };
 
 export const getEventById = async (req, res) => {
@@ -83,20 +81,20 @@ export const getEventById = async (req, res) => {
     const event = await Event.findById(req.params.eventId);
     if (!event) {
       return res.status(404).json({
-        status: "fail",
-        message: "No event found with that ID",
+        status: 'fail',
+        errors: ['No event found with that ID'],
       });
     }
     return res.status(200).json({
-      status: "success",
+      status: 'success',
       data: {
         event,
       },
     });
   } catch (e) {
     return res.status(500).json({
-      status: "fail",
-      message: e.message,
+      status: 'fail',
+      errors: [e.message],
     });
   }
 };
@@ -104,25 +102,29 @@ export const getEventById = async (req, res) => {
 export const updateEvent = async (req, res) => {
   try {
     const updateData = req.body;
-  
-    const updatedEvent = await Event.findByIdAndUpdate(req.params.eventId, updateData, { new: true, runValidators: true });
+
+    const updatedEvent = await Event.findByIdAndUpdate(
+      req.params.eventId,
+      updateData,
+      { new: true, runValidators: true }
+    );
     if (!updatedEvent) {
       return res.status(404).json({
-        status: "fail",
-        message: "No event found with that ID",
+        status: 'fail',
+        errors: ['No event found with that ID'],
       });
     }
 
     return res.status(200).json({
-      status: "success",
+      status: 'success',
       data: {
         event: updatedEvent,
       },
     });
   } catch (e) {
     return res.status(500).json({
-      status: "fail",
-      message: e.message,
+      status: 'fail',
+      errors: [e.message],
     });
   }
 };
@@ -132,19 +134,19 @@ export const deleteEvent = async (req, res) => {
     const event = await Event.findById(req.params.eventId);
     if (!event) {
       return res.status(404).json({
-        status: "fail",
-        message: "No event found with that ID",
+        status: 'fail',
+        errors: ['No event found with that ID'],
       });
     }
     await Event.findByIdAndDelete(req.params.eventId);
     return res.status(204).json({
-      status: "success",
-      data: "Deleted event!",
+      status: 'success',
+      data: 'Deleted event!',
     });
   } catch (e) {
     return res.status(500).json({
-      status: "fail",
-      message: e.message,
+      status: 'fail',
+      errors: [e.message],
     });
   }
 };
@@ -157,29 +159,29 @@ export const addComment = async (req, res) => {
     const event = await Event.findById(req.params.eventId);
     if (!event) {
       return res.status(404).json({
-        status: "fail",
-        message: "No event found with that ID",
+        status: 'fail',
+        errors: ['No event found with that ID'],
       });
     }
 
     event.comments.push({
       userId: user._id,
       comment: comment,
-      createdAt: new Date()
+      createdAt: new Date(),
     });
 
     const updatedEvent = await event.save();
 
     return res.status(200).json({
-      status: "success",
+      status: 'success',
       data: {
         event: updatedEvent,
       },
     });
   } catch (e) {
     return res.status(500).json({
-      status: "fail",
-      message: e.message,
+      status: 'fail',
+      errors: [e.message],
     });
   }
 };
@@ -192,22 +194,24 @@ export const deleteComment = async (req, res) => {
     const event = await Event.findById(eventId);
     if (!event) {
       return res.status(404).json({
-        status: "fail",
-        message: "No event found with that ID",
+        status: 'fail',
+        errors: ['No event found with that ID'],
       });
     }
 
-    event.comments = event.comments.filter(comment => comment._id.toString() !== commentId);
+    event.comments = event.comments.filter(
+      (comment) => comment._id.toString() !== commentId
+    );
     await event.save();
 
     return res.status(200).json({
-      status: "success",
-      message: "Comment deleted successfully",
+      status: 'success',
+      message: 'Comment deleted successfully',
     });
   } catch (e) {
     return res.status(500).json({
-      status: "fail",
-      message: e.message,
+      status: 'fail',
+      errors: [e.message],
     });
   }
 };
@@ -221,16 +225,18 @@ export const updateComment = async (req, res) => {
     const event = await Event.findById(eventId);
     if (!event) {
       return res.status(404).json({
-        status: "fail",
-        message: "No event found with that ID",
+        status: 'fail',
+        errors: ['No event found with that ID'],
       });
     }
 
-    const commentIndex = event.comments.findIndex(comment => comment._id.toString() === commentId);
+    const commentIndex = event.comments.findIndex(
+      (comment) => comment._id.toString() === commentId
+    );
     if (commentIndex === -1) {
       return res.status(404).json({
-        status: "fail",
-        message: "No comment found with that ID",
+        status: 'fail',
+        errors: ['No comment found with that ID'],
       });
     }
 
@@ -239,13 +245,13 @@ export const updateComment = async (req, res) => {
     await event.save();
 
     return res.status(200).json({
-      status: "success",
-      message: "Comment updated successfully",
+      status: 'success',
+      message: 'Comment updated successfully',
     });
   } catch (e) {
     return res.status(500).json({
-      status: "fail",
-      message: e.message,
+      status: 'fail',
+      errors: [e.message],
     });
   }
 };
@@ -253,50 +259,57 @@ export const updateComment = async (req, res) => {
 export const addAttendee = async (req, res) => {
   try {
     const eventId = req.params.eventId;
-    console.log("eventID:" ,eventId)
     const loggedInUserId = req.user.id;
-    console.log("userID",loggedInUserId)
     const event = await Event.findById(eventId);
 
     if (!event) {
-      return res.status(404).json({ status: "fail", message: "Event not found" });
+      return res
+        .status(404)
+        .json({ status: 'fail', errors: ['Event not found'] });
     }
 
     if (event.attendees.includes(loggedInUserId)) {
-      return res.status(400).json({ status: "fail", message: "You are already registered as an attendee" });
+      return res.status(400).json({
+        status: 'fail',
+        errors: ['You are already registered as an attendee'],
+      });
     }
 
     event.attendees.push(loggedInUserId);
     const updatedEvent = await event.save();
 
-    res.status(200).json({ status: "success", data: { event: updatedEvent } });
+    res.status(200).json({ status: 'success', data: { event: updatedEvent } });
   } catch (e) {
-    res.status(500).json({ status: "fail", message: e.message });
+    res.status(500).json({ status: 'fail', errors: [e.message] });
   }
 };
-
 
 export const removeAttendee = async (req, res) => {
   try {
     const eventId = req.params.eventId;
     const attendeeId = req.body.attendeeId;
-   
+
     const event = await Event.findById(eventId);
 
     if (!event) {
-      return res.status(404).json({ status: "fail", message: "Event not found" });
+      return res
+        .status(404)
+        .json({ status: 'fail', errors: ['Event not found'] });
     }
 
     if (!event.attendees.includes(attendeeId)) {
-      return res.status(400).json({ status: "fail", message: "Attendee not found in event" });
+      return res
+        .status(400)
+        .json({ status: 'fail', errors: ['Attendee not found in event'] });
     }
 
-    event.attendees = event.attendees.filter(id => id.toString() !== attendeeId);
+    event.attendees = event.attendees.filter(
+      (id) => id.toString() !== attendeeId
+    );
 
     const updatedEvent = await event.save();
-    res.status(200).json({ status: "success", data: { event: updatedEvent } });
+    res.status(200).json({ status: 'success', data: { event: updatedEvent } });
   } catch (e) {
-    res.status(500).json({ status: "fail", message: e.message });
+    res.status(500).json({ status: 'fail', errors: [e.message] });
   }
 };
-

--- a/controllers/postsController.js
+++ b/controllers/postsController.js
@@ -1,16 +1,16 @@
-import Post from "../models/postModel.js";
+import Post from '../models/postModel.js';
 
 export const getAllPosts = async (req, res) => {
   try {
     const posts = await Post.find();
-    if (!posts) {
+    if (!posts || posts.length === 0) {
       return res.status(404).json({
-        status: "fail",
-        message: "No posts have been made yet",
+        status: 'fail',
+        errors: ['No posts have been made yet'],
       });
     }
     return res.status(200).json({
-      status: "success",
+      status: 'success',
       results: posts.length,
       data: {
         posts,
@@ -18,27 +18,26 @@ export const getAllPosts = async (req, res) => {
     });
   } catch (e) {
     return res.status(500).json({
-      status: "fail",
-      message: e.message,
+      status: 'fail',
+      errors: [e.message],
     });
   }
 };
 
 export const createPost = async (req, res) => {
-  console.log("first");
   try {
     const { title, description, author, img } = req.body;
     const newPost = await Post.create({ title, description, author, img });
     return res.status(201).json({
-      status: "success",
+      status: 'success',
       data: {
         post: newPost,
       },
     });
   } catch (e) {
     return res.status(500).json({
-      status: "fail",
-      message: e.message,
+      status: 'fail',
+      errors: [e.message],
     });
   }
 };
@@ -48,20 +47,20 @@ export const getPostById = async (req, res) => {
     const post = await Post.findById(req.params.id);
     if (!post) {
       return res.status(404).json({
-        status: "fail",
-        message: "No post found with that ID",
+        status: 'fail',
+        errors: ['No post found with that ID'],
       });
     }
     return res.status(200).json({
-      status: "success",
+      status: 'success',
       data: {
         post,
       },
     });
   } catch (e) {
     return res.status(500).json({
-      status: "fail",
-      message: e.message,
+      status: 'fail',
+      errors: [e.message],
     });
   }
 };
@@ -71,8 +70,8 @@ export const updatePost = async (req, res) => {
     const post = await Post.findById(req.params.id);
     if (!post) {
       return res.status(404).json({
-        status: "fail",
-        message: "No post found with that ID",
+        status: 'fail',
+        errors: ['No post found with that ID'],
       });
     }
     const { title, description, author, img } = req.body;
@@ -82,15 +81,15 @@ export const updatePost = async (req, res) => {
       { new: true }
     );
     return res.status(200).json({
-      status: "success",
+      status: 'success',
       data: {
         post: updatedPost,
       },
     });
   } catch (e) {
     return res.status(500).json({
-      status: "fail",
-      message: e.message,
+      status: 'fail',
+      errors: [e.message],
     });
   }
 };
@@ -100,19 +99,19 @@ export const deletePost = async (req, res) => {
     const post = await Post.findById(req.params.id);
     if (!post) {
       return res.status(404).json({
-        status: "fail",
-        message: "No post found with that ID",
+        status: 'fail',
+        errors: ['No post found with that ID'],
       });
     }
     await Post.findByIdAndDelete(req.params.id);
     return res.status(204).json({
-      status: "success",
-      data: "Deleted post!",
+      status: 'success',
+      data: 'Deleted post!',
     });
   } catch (e) {
     return res.status(500).json({
-      status: "fail",
-      message: e.message,
+      status: 'fail',
+      errors: [e.message],
     });
   }
 };
@@ -124,8 +123,8 @@ export const addComment = async (req, res) => {
     const post = await Post.findById(req.params.id);
     if (!post) {
       return res.status(404).json({
-        status: "fail",
-        message: "No post found with that ID",
+        status: 'fail',
+        errors: ['No post found with that ID'],
       });
     }
     const commentsKey = commentedBy(user);
@@ -138,39 +137,38 @@ export const addComment = async (req, res) => {
       },
       { new: true }
     );
-    console.log(updatedPost);
     return res.status(200).json({
-      status: "success",
+      status: 'success',
       data: {
         post: updatedPost,
       },
     });
   } catch (e) {
     return res.status(500).json({
-      status: "fail",
-      message: e.message,
+      status: 'fail',
+      errors: [e.message],
     });
   }
 };
 
 export const deleteComment = async (req, res) => {
-  res.send("this route is not yet defined");
+  res.send('this route is not yet defined');
 };
 
 export const updateComment = async (req, res) => {
-  res.send("this route is not yet defined");
+  res.send('this route is not yet defined');
 };
 
 const commentedBy = (user) => {
-  if ("isUser" in user) {
-    return "users";
+  if ('isUser' in user) {
+    return 'users';
   }
 
-  if ("isGym" in user) {
-    return "gyms";
+  if ('isGym' in user) {
+    return 'gyms';
   }
 
-  if ("isTrainer" in user) {
-    return "trainers";
+  if ('isTrainer' in user) {
+    return 'trainers';
   }
 };

--- a/controllers/sessionController.js
+++ b/controllers/sessionController.js
@@ -34,7 +34,6 @@ export const createSession = async (req, res) => {
       const errors = Object.values(validationErrors.errors).map(
         (error) => error.message
       );
-      console.log(errors);
       return res.status(400).json({ errors });
     }
 

--- a/public/js/loginClient.js
+++ b/public/js/loginClient.js
@@ -30,7 +30,6 @@ async function handleLogin(email, password, userType) {
 
     const response = await apiRequest('post', apiUrl, credentials);
     //sessionStorage.setItem('jwt', response.token);
-    console.log('Login successful! Token:', response.token);
     window.location.href = `/${userType}/dashboard`;
   } catch (error) {
     const errorContainer = document.getElementById('errorContainer');

--- a/public/js/trainerClient.js
+++ b/public/js/trainerClient.js
@@ -130,7 +130,6 @@ async function createSession(formData) {
     const apiUrl = '/session/createsession';
     const response = await apiRequest('post', apiUrl, formData);
 
-    console.log('Session created successfully!', response);
     window.location.href = '/trainer/sessions';
   } catch (error) {
     console.error('Error creating session:', error);
@@ -258,7 +257,6 @@ async function endSession(sessionId, sessionType, registeredUsersCount) {
     const apiUrl = `/session/toggle/${sessionId}`;
     const response = await apiRequest('post', apiUrl);
 
-    console.log(`Session ${sessionId} ended successfully!`, response);
     window.location.href = '/trainer/sessions';
   } catch (error) {
     console.error(`Error toggling session ${sessionId}:`, error);


### PR DESCRIPTION
1) All APIs should return errors array during fail cases to keep the API consistent
2) Removed console.logs 